### PR TITLE
Disable pylint error

### DIFF
--- a/source/openpulse/openpulse/parser.py
+++ b/source/openpulse/openpulse/parser.py
@@ -35,7 +35,7 @@ except ImportError as exc:
     ) from exc
 
 import openpulse.ast as openpulse_ast
-from openqasm3._antlr.qasm3Parser import qasm3Parser
+from openqasm3._antlr.qasm3Parser import qasm3Parser  # pylint: disable=import-error
 from openqasm3 import ast
 from openqasm3.parser import (
     span,


### PR DESCRIPTION
@hodgestar I did not read the `pylint` failure closely enough. The error wasn't that the import failed, but rather that `openqasm3._antlr` is by Python standards a private module (because of the `_` prefix). This should fix it. Maybe pylint is less strict for Python 3.7...